### PR TITLE
Use cargo feature to enable, rather than disable, sysex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ license = "MIT"
 keywords = ["midi", "music"]
 
 [dependencies]
-ascii = { git="https://github.com/tomprogrammer/rust-ascii", rev="1a91033", default-features = false, features = ["alloc"] }
+ascii = { git="https://github.com/tomprogrammer/rust-ascii", rev="1a91033", default-features = false, features = ["alloc"], optional = true }
 micromath = "1.1.1"
 
 [features]
-default = ["std"]
+default = ["std", "sysex"]
 std = []
-no_sysex = []
+sysex = ["ascii"]

--- a/readme.md
+++ b/readme.md
@@ -20,20 +20,19 @@ midi-msg = "0.4"
 If you want to use midi-msg in a `no_std` environment, add this line instead:
 
 ```
-midi-msg = { version = "0.4", default-features = false }
+midi-msg = { version = "0.4", default-features = false, features=["sysex"] }
 ```
-
 
 ## Disabling system exclusive functionality
 
-The `no_sysex` Cargo feature can be used to exclude code related to system exclusive functionality, which can be useful to reduce the binary size in resource constrained environments. If `no_sysex` is used and an attempt is made to parse a system exclusive message, an error will be returned.
+The default `sysex` Cargo feature can be disabled to exclude code related to system exclusive functionality, which can be useful to reduce the binary size in resource constrained environments. If `sysex` is not used and an attempt is made to parse a system exclusive message, an error will be returned.
 
 
 ## To be implemented
 - Deserialization of most of `UniversalRealTimeMsg` and `UniversalNonRealTimeMsg`
 
 
-## Support 
+## Support
 MIDI messages described by the following [Midi Manufacturer Association (MMA) documents](https://www.midi.org/specifications/midi1-specifications) are supported (with their corresponding Midi Manufacturer Association [MMA] publication number, Recommended Practice [RP] number, or Changes/Additions [CA] number as noted):
 
 - MIDI 1.0 Detailed Specification 4.2.1 (The base specification. All types should be assumed to be defined by this document unless otherwise specified)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub use message::*;
 // A helper used in tests
 #[cfg(test)]
 pub fn test_serialization(msg: MidiMsg, ctx: &mut ReceiverContext) {
+    #[cfg(not(feature = "std"))]
     use crate::alloc::format;
 
     let midi = msg.to_midi();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,9 @@ mod system_common;
 pub use system_common::*;
 mod system_real_time;
 pub use system_real_time::*;
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 mod system_exclusive;
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 pub use system_exclusive::*;
 
 mod message;

--- a/src/message.rs
+++ b/src/message.rs
@@ -159,7 +159,7 @@ impl MidiMsg {
                             return Ok((Self::SystemExclusive { msg }, len));
                         }
                         #[cfg(not(feature = "sysex"))]
-                        return Err(ParseError::Invalid(format!("Got system exclusive message but the crate was built with no_sysex.")))
+                        return Err(ParseError::Invalid(format!("Got system exclusive message but the crate was built without the sysex feature.")))
                     } else if b & 0b00001000 == 0 {
                         let (msg, len) = SystemCommonMsg::from_midi(m, ctx)?;
                         Ok((Self::SystemCommon { msg }, len))

--- a/src/message.rs
+++ b/src/message.rs
@@ -7,7 +7,7 @@ use super::{
     SystemRealTimeMsg,
 };
 
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 use super::SystemExclusiveMsg;
 
 /// The primary interface of this library. Used to encode MIDI messages.
@@ -45,7 +45,7 @@ pub enum MidiMsg {
     SystemRealTime { msg: SystemRealTimeMsg },
     /// The bulk of the MIDI spec lives here, in "Universal System Exclusive" messages.
     /// Also the home of manufacturer-specific messages.
-    #[cfg(not(feature = "no_sysex"))]
+    #[cfg(feature = "sysex")]
     SystemExclusive { msg: SystemExclusiveMsg },
 }
 
@@ -153,12 +153,12 @@ impl MidiMsg {
                 }
                 0xF => {
                     if b & 0b00001111 == 0 {
-                        #[cfg(not(feature = "no_sysex"))]
+                        #[cfg(feature = "sysex")]
                         {
                             let (msg, len) = SystemExclusiveMsg::from_midi(m, ctx)?;
                             return Ok((Self::SystemExclusive { msg }, len));
                         }
-                        #[cfg(feature = "no_sysex")]
+                        #[cfg(not(feature = "sysex"))]
                         return Err(ParseError::Invalid(format!("Got system exclusive message but the crate was built with no_sysex.")))
                     } else if b & 0b00001000 == 0 {
                         let (msg, len) = SystemCommonMsg::from_midi(m, ctx)?;
@@ -284,7 +284,7 @@ impl MidiMsg {
             MidiMsg::RunningChannelMode { msg, .. } => msg.extend_midi_running(v),
             MidiMsg::SystemCommon { msg } => msg.extend_midi(v),
             MidiMsg::SystemRealTime { msg } => msg.extend_midi(v),
-            #[cfg(not(feature = "no_sysex"))]
+            #[cfg(feature = "sysex")]
             MidiMsg::SystemExclusive { msg } => msg.extend_midi(v),
         }
     }

--- a/src/time_code.rs
+++ b/src/time_code.rs
@@ -101,7 +101,7 @@ impl Default for TimeCodeType {
     }
 }
 
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 mod sysex_types {
     use super::*;
     use ascii::AsciiString;
@@ -753,11 +753,11 @@ mod sysex_types {
     }
 }
 
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 pub use sysex_types::*;
 
 #[cfg(test)]
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 mod tests {
     use crate::*;
     use std::vec;

--- a/src/util.rs
+++ b/src/util.rs
@@ -143,8 +143,10 @@ pub fn freq_to_midi_note_cents(freq: f32) -> (u8, f32) {
     (semitone as u8, F32Ext::fract(semitone) * 100.0)
 }
 
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 mod sysex_util {
+    use alloc::vec::Vec;
+
     #[inline]
     pub fn push_i14(x: i16, v: &mut Vec<u8>) {
         let [msb, lsb] = to_i14(x);
@@ -248,7 +250,7 @@ mod sysex_util {
     }
 }
 
-#[cfg(not(feature = "no_sysex"))]
+#[cfg(feature = "sysex")]
 pub use sysex_util::*;
 
 #[cfg(test)]
@@ -300,7 +302,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_sysex"))]
+    #[cfg(feature = "sysex")]
     fn test_to_i14() {
         assert_eq!(to_i14(0xff), [0x01, 0x7f]);
         assert_eq!(to_i14(0x6f00), [0x3f, 0x7f]); // Overflow is treated as max value
@@ -314,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_sysex"))]
+    #[cfg(feature = "sysex")]
     fn test_to_u21() {
         assert_eq!(to_u21(0xff), [0, 1, 127]);
         assert_eq!(to_u21(0xff00), [3, 126, 0]);
@@ -328,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "no_sysex"))]
+    #[cfg(feature = "sysex")]
     fn text_checksum() {
         assert_eq!(checksum(&[0b11110000, 0b00001111, 0b10101010]), 0b01010101);
         assert_eq!(
@@ -337,14 +339,14 @@ mod tests {
         )
     }
 
-    #[cfg(not(feature = "no_sysex"))]
+    #[cfg(feature = "sysex")]
     fn freq_to_midi_note_u14(freq: f32) -> (u8, u16) {
         let (n, c) = crate::freq_to_midi_note_cents(freq);
         (n, cents_to_u14(c))
     }
 
     #[test]
-    #[cfg(not(feature = "no_sysex"))]
+    #[cfg(feature = "sysex")]
     fn test_freq_to_midi_note() {
         // The test data below is taken from the "Frequency data format" section (page 48)
         // of The MIDI 1.0 Detailed Specification 4.2.1.


### PR DESCRIPTION
Currently, the `no_sysex` feature is used to disable sysex related code. This PR replaces this feature with the `sysex` feature, which _enables_ sysex related code, so that the `ascii` dependency can be excluded if the crate is built without sysex