### PR TITLE
Serialize MIDI message into existing vector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@
 //! .to_midi();
 //! ```
 //!
+//! To serialize a MIDI message into an existing vector, use [`MidiMsg::append_midi`].
+//! This is useful in real time and resource constrained environments where
+//! memory allocations should be avoided.
+//!
 //! ## Deserializing MIDI byte sequences
 //! Likewise, byte sequences can be deserialized into `MidiMsg`s with [`MidiMsg::from_midi`]:
 //!

--- a/src/message.rs
+++ b/src/message.rs
@@ -50,11 +50,18 @@ pub enum MidiMsg {
 }
 
 impl MidiMsg {
-    /// Turn a `MidiMsg` into a series of bytes.
+    /// Turn a `MidiMsg` into a series of bytes and return
+    /// the result in a newly allocated vector.
     pub fn to_midi(&self) -> Vec<u8> {
         let mut r: Vec<u8> = vec![];
-        self.extend_midi(&mut r);
+        self.append_midi(&mut r);
         r
+    }
+
+    /// Turn a `MidiMsg` into a series of bytes and push them
+    /// onto a given vector.
+    pub fn append_midi(&self, r: &mut Vec<u8>) {
+        self.extend_midi(r);
     }
 
     /// Turn a series of bytes into a `MidiMsg`.

--- a/src/message.rs
+++ b/src/message.rs
@@ -58,7 +58,7 @@ impl MidiMsg {
         r
     }
 
-    /// Turn a `MidiMsg` into a series of bytes and push them
+    /// Turn a `MidiMsg` into a series of bytes and push the result
     /// onto a given vector.
     pub fn append_midi(&self, r: &mut Vec<u8>) {
         self.extend_midi(r);


### PR DESCRIPTION
`MidiMsg::to_midi` returns a newly allocated array of MIDI bytes which is fine for many use cases. However, this is not ideal in real time and resource constrained environments where allocations should be avoided. This PR adds `MidiMsg::append_midi`, which allows serialization of MIDI messages into an existing pre-allocated vector.