### PR TITLE
Mark all enums & structs that derive PartialEq also derive Eq, where possible

### DIFF
--- a/src/channel_mode.rs
+++ b/src/channel_mode.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use super::parse_error::*;
 use crate::util::*;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Channel-level messages that should alter the mode of the receiver. Used in [`MidiMsg`](crate::MidiMsg).
 pub enum ChannelModeMsg {
     /// Sound playing on the channel should be stopped as soon as possible, per GM2.
@@ -88,7 +88,7 @@ impl ChannelModeMsg {
 }
 
 /// Used by [`ChannelModeMsg::PolyMode`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PolyMode {
     /// Request that the receiver be monophonic, with the given number M representing the
     /// number of channels that should be dedicated. Since this is sent with a `ChannelModeMsg`

--- a/src/channel_voice.rs
+++ b/src/channel_voice.rs
@@ -6,7 +6,7 @@ use alloc::format;
 
 /// Channel-level messages that act on a voice. For instance, turning notes on off,
 /// or modifying sounding notes. Used in [`MidiMsg`](crate::MidiMsg).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChannelVoiceMsg {
     /// Turn on a note
     NoteOn {
@@ -269,7 +269,7 @@ impl ChannelVoiceMsg {
 }
 
 /// An enum that defines the MIDI numbers associated with Control Changes.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlNumber {
     BankSelect = 0,
     BankSelectLSB = 32,
@@ -355,7 +355,7 @@ pub enum ControlNumber {
 
 /// Used by [`ChannelVoiceMsg::ControlChange`] to modify sounds.
 /// Each control targets a particular [`ControlNumber`], the meaning of which is given by convention.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlChange {
     /// 0-16383
     BankSelect(u16),
@@ -956,7 +956,7 @@ impl ControlChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// Used by [`ControlChange::Parameter`]. "Entry" Parameters can be used to set the given parameters:
 /// they will first select that parameter, then send a [`ControlChange::DataEntry`] with the given value.
 pub enum Parameter {

--- a/src/general_midi.rs
+++ b/src/general_midi.rs
@@ -1,7 +1,7 @@
 /// Used to turn General MIDI level 1 or 2 on, or turn them off.
 ///
 /// Used in [`UniversalNonRealTimeMsg::GeneralMidi`](crate::UniversalNonRealTimeMsg::GeneralMidi)
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GeneralMidi {
     GM1 = 1,
     GM2 = 3,
@@ -25,7 +25,7 @@ pub enum GeneralMidi {
 /// Should not be used when targeting channel 10.
 ///
 /// As defined in General MIDI System Level 1 (MMA0007 / RP003).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GMSoundSet {
     AcousticGrandPiano = 0,
     BrightAcousticPiano = 1,
@@ -174,7 +174,7 @@ pub enum GMSoundSet {
 /// ```
 ///
 /// As defined in General MIDI System Level 1 (MMA0007 / RP003).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GMPercussionMap {
     AcousticBassDrum = 35,
     RideCymbal1 = 51,

--- a/src/message.rs
+++ b/src/message.rs
@@ -297,7 +297,7 @@ impl From<&MidiMsg> for Vec<u8> {
 }
 
 /// The MIDI channel, 1-16. Used by [`MidiMsg`] and elsewhere.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Channel {
     Ch1,
     Ch2,

--- a/src/system_common.rs
+++ b/src/system_common.rs
@@ -7,7 +7,7 @@ use super::ReceiverContext;
 
 /// A fairly limited set of messages, generally for device synchronization.
 /// Used in [`MidiMsg`](crate::MidiMsg).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SystemCommonMsg {
     /// The first of 8 "quarter frame" messages, which are meant to be sent 4 per "frame".
     /// These messages function similarly to [`SystemRealTimeMsg::TimingClock`](crate::SystemRealTimeMsg::TimingClock)

--- a/src/system_exclusive/controller_destination.rs
+++ b/src/system_exclusive/controller_destination.rs
@@ -8,7 +8,7 @@ use crate::util::*;
 /// Used by [`UniversalRealTimeMsg`](crate::UniversalRealTimeMsg).
 ///
 /// Defined in CA-022.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControllerDestination {
     pub channel: Channel,
     /// Any number of (ControlledParameter, range) pairs
@@ -34,7 +34,7 @@ impl ControllerDestination {
 /// Used by [`UniversalRealTimeMsg::GlobalParameterControl`](crate::UniversalRealTimeMsg::GlobalParameterControl).
 ///
 /// Defined in CA-022.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlChangeControllerDestination {
     pub channel: Channel,
     /// A control number between `0x01` - `0x1F` or `0x40` - `0x5F`
@@ -65,7 +65,7 @@ impl ControlChangeControllerDestination {
 }
 /// The parameters that can be controlled by [`ControllerDestination`] or
 /// [`ControlChangeControllerDestination`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlledParameter {
     PitchControl = 0,
     FilterCutoffControl = 1,

--- a/src/system_exclusive/file_dump.rs
+++ b/src/system_exclusive/file_dump.rs
@@ -7,7 +7,7 @@ use ascii::{AsciiChar, AsciiString};
 
 /// Used to transmit general file data.
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileDumpMsg {
     /// Request that the file with `name` be sent.
     Request {
@@ -119,7 +119,7 @@ impl FileDumpMsg {
 }
 
 /// A four-character file type used by [`FileDumpMsg`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FileType {
     MIDI,
     MIEX,

--- a/src/system_exclusive/file_reference.rs
+++ b/src/system_exclusive/file_reference.rs
@@ -9,7 +9,7 @@ use ascii::{AsciiChar, AsciiString};
 /// Used by [`UniversalNonRealTimeMsg::FileReference`](crate::UniversalNonRealTimeMsg::FileReference).
 ///
 /// As defined in CA-018.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileReferenceMsg {
     /// Describe where a file is located for opening, but must be followed by a `SelectContents`
     /// message if any sounds are to play.
@@ -94,7 +94,7 @@ impl FileReferenceMsg {
 }
 
 /// The file type of a given file, as used by [`FileReferenceMsg`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FileReferenceType {
     DLS,
     SF2,
@@ -127,7 +127,7 @@ impl FileReferenceType {
 }
 
 /// How to map a `DLS` or `SF2` file for MIDI reference. Used by [`SelectMap`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SoundFileMap {
     /// MIDI bank number required to select sound for playing. 0-16383
     pub dst_bank: u16,
@@ -178,7 +178,7 @@ impl SoundFileMap {
 }
 
 /// How to map a `WAV` file for MIDI reference. Used by [`SelectMap`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct WAVMap {
     /// MIDI bank number required to select sound for playing. 0-16383
     pub dst_bank: u16,
@@ -226,7 +226,7 @@ impl Default for WAVMap {
 }
 
 /// How to map a file for MIDI reference. Used by [`FileReferenceMsg::SelectContents`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SelectMap {
     /// Used for DLS or SF2 files. No more than 127 `SoundFileMap`s.
     ///

--- a/src/system_exclusive/global_parameter.rs
+++ b/src/system_exclusive/global_parameter.rs
@@ -13,7 +13,7 @@ use crate::util::*;
 /// As defined in CA-024.
 ///
 /// This C/A is much more permissive than most, and thus has a pretty awkward interface.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalParameterControl {
     /// Between 0 and 127 `SlotPath`s, with each successive path representing a child
     /// of the preceding value. No paths refers to the "top level"
@@ -29,7 +29,7 @@ pub struct GlobalParameterControl {
     pub params: Vec<GlobalParameter>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// The type of reverb, used by [`GlobalParameterControl::reverb`].
 pub enum ReverbType {
     SmallRoom = 0,
@@ -40,7 +40,7 @@ pub enum ReverbType {
     Plate = 8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// The type of chorus, used by [`GlobalParameterControl::chorus`].
 pub enum ChorusType {
     Chorus1 = 0,
@@ -163,7 +163,7 @@ impl GlobalParameterControl {
 
 /// The "slot" of the device being referred to by [`GlobalParameterControl`].
 /// Values other than `Unregistered` come from the General MIDI 2 spec.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SlotPath {
     Reverb,
     Chorus,
@@ -196,7 +196,7 @@ impl SlotPath {
 }
 
 /// An `id`:`value` pair that must line up with the [`GlobalParameterControl`] that it is placed in.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalParameter {
     pub id: Vec<u8>,
     pub value: Vec<u8>,

--- a/src/system_exclusive/key_based_instrument_control.rs
+++ b/src/system_exclusive/key_based_instrument_control.rs
@@ -9,7 +9,7 @@ use crate::util::*;
 /// Used by [`UniversalRealTimeMsg::KeyBasedInstrumentControl`](crate::UniversalRealTimeMsg::KeyBasedInstrumentControl).
 ///
 /// Defined in CA-023.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyBasedInstrumentControl {
     pub channel: Channel,
     /// The MIDI key number.

--- a/src/system_exclusive/machine_control.rs
+++ b/src/system_exclusive/machine_control.rs
@@ -10,7 +10,7 @@ use crate::time_code::*;
 /// represent commands not supported here.
 ///
 /// As defined in MIDI Machine Control 1.0 (MMA0016 / RP013)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MachineControlCommandMsg {
     Stop,
     Play,
@@ -81,7 +81,7 @@ impl MachineControlCommandMsg {
 /// A MIDI Machine Control Information Field, which functions something like an address
 ///
 /// As defined in MIDI Machine Control 1.0 (MMA0016 / RP013)
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InformationField {
     SelectedTimeCode = 0x01,
     SelectedMasterCode = 0x02,
@@ -108,7 +108,7 @@ pub enum InformationField {
 /// Not implemented. The `Unimplemented` value can be used to represent generic responses.
 ///
 /// As defined in MIDI Machine Control 1.0 (MMA0016 / RP013)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MachineControlResponseMsg {
     /// Used to represent all unimplemented MCR messages.
     /// Is inherently not guaranteed to be a valid message.

--- a/src/system_exclusive/mod.rs
+++ b/src/system_exclusive/mod.rs
@@ -165,7 +165,7 @@ impl SystemExclusiveMsg {
 ///
 /// If second byte is None, it is a one-byte ID.
 /// The first byte in a one-byte ID may not be greater than 0x7C.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ManufacturerID(u8, Option<u8>);
 
 impl ManufacturerID {
@@ -205,7 +205,7 @@ impl From<(u8, u8)> for ManufacturerID {
 
 /// The device ID being addressed, either a number between 0-126 or `AllCall` (all devices).
 /// Used by [`SystemExclusiveMsg::UniversalNonRealTime`] and [`SystemExclusiveMsg::UniversalRealTime`].
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceID {
     Device(u8),
     AllCall,
@@ -617,7 +617,7 @@ impl UniversalNonRealTimeMsg {
 /// A response to [`UniversalNonRealTimeMsg::IdentityRequest`], meant to indicate the type of device
 /// that this message is sent from.
 /// Used by [`UniversalNonRealTimeMsg::IdentityReply`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct IdentityReply {
     pub id: ManufacturerID,
     pub family: u16,

--- a/src/system_exclusive/notation.rs
+++ b/src/system_exclusive/notation.rs
@@ -7,7 +7,7 @@ use crate::util::*;
 /// Indicates that the next MIDI clock message is the first clock of a new measure. Which bar
 /// is optionally indicated by this message.
 /// Used by [`UniversalRealTimeMsg::BarMarker`](crate::UniversalRealTimeMsg::BarMarker).
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BarMarker {
     /// "Actually, we're not running right now, so there is no bar." Don't know why this is used.
     NotRunning,
@@ -49,7 +49,7 @@ impl BarMarker {
 
 /// Used to communicate a new time signature to the receiver.
 /// Used by [`UniversalRealTimeMsg`](crate::UniversalRealTimeMsg).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimeSignature {
     /// The base time signature.
     pub signature: Signature,
@@ -97,7 +97,7 @@ impl TimeSignature {
 }
 
 /// A [time signature](https://en.wikipedia.org/wiki/Time_signature). Used by [`TimeSignature`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Signature {
     /// Number of beats in a bar.
     pub beats: u8,
@@ -127,7 +127,7 @@ impl Default for Signature {
 }
 
 /// The note value of a beat, used by [`Signature`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BeatValue {
     Whole,
     Half,

--- a/src/system_exclusive/sample_dump.rs
+++ b/src/system_exclusive/sample_dump.rs
@@ -6,7 +6,7 @@ use ascii::AsciiString;
 
 /// Used to request and transmit sampler data.
 /// Used by [`UniversalNonRealTimeMsg::SampleDump`](crate::UniversalNonRealTimeMsg::SampleDump).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SampleDumpMsg {
     /// Request that the receiver send the given sample.
     Request {
@@ -138,7 +138,7 @@ impl SampleDumpMsg {
 }
 
 /// What loop a [`SampleDumpMsg`] or [`ExtendedSampleDumpMsg`] is referring to.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LoopNumber {
     /// A loop with the given ID, 0-16382.
     Loop(u16),
@@ -165,7 +165,7 @@ impl LoopNumber {
 }
 
 /// The type of loop being described by a [`SampleDumpMsg`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LoopType {
     /// Forward only
     Forward = 0,
@@ -295,7 +295,7 @@ impl ExtendedSampleDumpMsg {
 }
 
 /// The type of loop being described by a [`SampleDumpMsg`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ExtendedLoopType {
     /// A forward, unidirectional loop
     Forward = 0x00,

--- a/src/system_exclusive/show_control.rs
+++ b/src/system_exclusive/show_control.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 use alloc::format;
 use crate::parse_error::*;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// A MIDI Show Control command.
 /// Used by [`UniversalRealTimeMsg::ShowControl`](crate::UniversalRealTimeMsg::ShowControl).
 ///

--- a/src/system_exclusive/tuning.rs
+++ b/src/system_exclusive/tuning.rs
@@ -6,7 +6,7 @@ use ascii::AsciiChar;
 
 /// Change the tunings of one or more notes, either real-time or not.
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg) and [`UniversalRealTimeMsg`](crate::UniversalRealTimeMsg).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TuningNoteChange {
     /// Which tuning program is targeted, 0-127. See [`Parameter::TuningProgramSelect`](crate::Parameter::TuningProgramSelect).
     pub tuning_program_num: u8,
@@ -43,7 +43,7 @@ impl TuningNoteChange {
 
 /// Set the tunings of all 128 notes.
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyBasedTuningDump {
     /// Which tuning program is targeted, 0-127. See [`Parameter::TuningProgramSelect`](crate::Parameter::TuningProgramSelect).
     pub tuning_program_num: u8,
@@ -99,7 +99,7 @@ impl KeyBasedTuningDump {
 }
 
 /// Used to represent a tuning by [`TuningNoteChange`] and [`KeyBasedTuningDump`].
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Tuning {
     /// The semitone corresponding with the same MIDI note number, 0-127
     pub semitone: u8,
@@ -141,7 +141,7 @@ impl Tuning {
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg).
 ///
 /// As defined in MIDI Tuning Updated Specification (CA-020/CA-021/RP-020)
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ScaleTuningDump1Byte {
     /// Which tuning program is targeted, 0-127. See [`Parameter::TuningProgramSelect`](crate::Parameter::TuningProgramSelect).
     pub tuning_program_num: u8,
@@ -180,7 +180,7 @@ impl ScaleTuningDump1Byte {
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg).
 ///
 /// As defined in MIDI Tuning Updated Specification (CA-020/CA-021/RP-020)
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ScaleTuningDump2Byte {
     /// Which tuning program is targeted, 0-127. See [`Parameter::TuningProgramSelect`](crate::Parameter::TuningProgramSelect).
     pub tuning_program_num: u8,
@@ -221,7 +221,7 @@ impl ScaleTuningDump2Byte {
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg) and [`UniversalRealTimeMsg`](crate::UniversalRealTimeMsg).
 ///
 /// As defined in MIDI Tuning Updated Specification (CA-020/CA-021/RP-020)
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ScaleTuning1Byte {
     pub channels: ChannelBitMap,
     /// 12 semitones of tuning adjustments repeated over all octaves, starting with C
@@ -248,7 +248,7 @@ impl ScaleTuning1Byte {
 /// Used by [`UniversalNonRealTimeMsg`](crate::UniversalNonRealTimeMsg) and [`UniversalRealTimeMsg`](crate::UniversalRealTimeMsg).
 ///
 /// As defined in MIDI Tuning Updated Specification (CA-020/CA-021/RP-020)
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ScaleTuning2Byte {
     pub channels: ChannelBitMap,
     /// 12 semitones of tuning adjustments repeated over all octaves, starting with C
@@ -274,7 +274,7 @@ impl ScaleTuning2Byte {
 }
 
 /// The set of channels to apply this tuning message to. Used by [`ScaleTuning1Byte`] and [`ScaleTuning2Byte`].
-#[derive(Debug, Copy, Clone, PartialEq, Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub struct ChannelBitMap {
     pub channel_1: bool,
     pub channel_2: bool,

--- a/src/system_real_time.rs
+++ b/src/system_real_time.rs
@@ -4,7 +4,7 @@ use super::parse_error::*;
 
 /// A fairly limited set of messages used for device synchronization.
 /// Used in [`MidiMsg`](crate::MidiMsg).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SystemRealTimeMsg {
     /// Used to synchronize clocks. Sent at a rate of 24 per quarter note.
     TimingClock,

--- a/src/time_code.rs
+++ b/src/time_code.rs
@@ -6,7 +6,7 @@ use super::util::*;
 /// Based on [the SMTPE time code standard](https://en.wikipedia.org/wiki/SMPTE_timecode).
 ///
 /// As defined in the MIDI Time Code spec (MMA0001 / RP004 / RP008)
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct TimeCode {
     /// The position in frames, 0-29
     pub frames: u8,
@@ -83,7 +83,7 @@ impl TimeCode {
 /// Indicates the frame rate of the given [`TimeCode`].
 ///
 /// See [the SMTPE time code standard](https://en.wikipedia.org/wiki/SMPTE_timecode).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimeCodeType {
     /// 24 Frames per second
     FPS24 = 0,
@@ -136,7 +136,7 @@ mod sysex_types {
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     /// Like [`TimeCode`] but includes `fractional_frames`. Used in `TimeCodeCueingSetupMsg`.
     ///
     /// As defined in the MIDI Time Code spec (MMA0001 / RP004 / RP008)
@@ -173,7 +173,7 @@ mod sysex_types {
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     /// Like [`TimeCode`] but uses `subframes` to optionally include status flags, and fractional frames.
     /// Also may be negative. Used in [`MachineControlCommandMsg`](crate::MachineControlCommandMsg).
     ///
@@ -245,7 +245,7 @@ mod sysex_types {
     }
 
     /// Used by [`StandardTimeCode`].
-    #[derive(Debug, Clone, Copy, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum SubFrames {
         /// The position in fractional frames, 0-99
         FractionalFrames(u8),
@@ -269,7 +269,7 @@ mod sysex_types {
     }
 
     /// Used by [`StandardTimeCode`].
-    #[derive(Debug, Clone, Copy, PartialEq, Default)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
     pub struct TimeCodeStatus {
         pub estimated_code: bool,
         pub invalid_code: bool,
@@ -300,7 +300,7 @@ mod sysex_types {
     /// See [the SMTPE time code standard](https://en.wikipedia.org/wiki/SMPTE_timecode).
     ///
     /// As defined in the MIDI Time Code spec (MMA0001 / RP004 / RP008)
-    #[derive(Debug, Copy, Clone, PartialEq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct UserBits {
         /// Full bytes can be used here. Sent such that the first is considered
         /// the "most significant" value
@@ -333,7 +333,7 @@ mod sysex_types {
     /// Like [`UserBits`] but allows for the embedding of a "secondary time code".
     ///
     /// As defined in MIDI Machine Control 1.0 (MMA0016 / RP013)
-    #[derive(Debug, Copy, Clone, PartialEq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct StandardUserBits {
         /// Full bytes can be used here. Sent such that the first is considered
         /// the "most significant" value


### PR DESCRIPTION
Motivation: Allows constant expressions to be used in `match` expressions like:

```rust
const YAMAHA: ManufacturerID = ManufacturerID(0x43, None);
// ...
    match msg {
        MidiMsg::SystemExclusive { msg: SystemExclusiveMsg::Commercial { id: YAMAHA, data } } => {
```

This leaves out `ExtendedSampleDumpMsg` because it contains an `f64`. That indirectly causes the following types to also be left out:
 - `MidiMsg`
 - `SystemExclusiveMsg`
 - `ReceiverContext`
 - `UniversalRealTimeMsg`
 - `UniversalNonRealTimeMsg`
 - `ExtendedSampleDumpMsg`
 - `TimeCodeCueingSetupMsg`
 - `TimeCodeCueingMsg`

Possible remedies for the f64:
 - https://docs.rs/ordered-float/2.10.0/ordered_float/struct.NotNan.html
 - https://docs.rs/fixed/1.11.0/fixed/types/type.U36F28.html or maybe https://docs.rs/fixed/1.11.0/fixed/types/type.U32F32.html