### PR TITLE
Specialize error messages for unimplemented from_midi() conversions

### DIFF
--- a/src/system_exclusive/controller_destination.rs
+++ b/src/system_exclusive/controller_destination.rs
@@ -26,7 +26,7 @@ impl ControllerDestination {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ControllerDestination not implemented")))
     }
 }
 
@@ -60,7 +60,7 @@ impl ControlChangeControllerDestination {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ControlChangeControllerDestination not implemented")))
     }
 }
 /// The parameters that can be controlled by [`ControllerDestination`] or

--- a/src/system_exclusive/file_dump.rs
+++ b/src/system_exclusive/file_dump.rs
@@ -114,7 +114,7 @@ impl FileDumpMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: FileDumpMsg not implemented")))
     }
 }
 

--- a/src/system_exclusive/file_reference.rs
+++ b/src/system_exclusive/file_reference.rs
@@ -89,7 +89,7 @@ impl FileReferenceMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: FileReferenceMsg not implemented")))
     }
 }
 

--- a/src/system_exclusive/global_parameter.rs
+++ b/src/system_exclusive/global_parameter.rs
@@ -157,7 +157,7 @@ impl GlobalParameterControl {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: GlobalParameterControl not implemented")))
     }
 }
 
@@ -191,7 +191,7 @@ impl SlotPath {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: SlotPath not implemented")))
     }
 }
 
@@ -229,7 +229,7 @@ impl GlobalParameter {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: GlobalParameter not implemented")))
     }
 }
 

--- a/src/system_exclusive/key_based_instrument_control.rs
+++ b/src/system_exclusive/key_based_instrument_control.rs
@@ -40,7 +40,7 @@ impl KeyBasedInstrumentControl {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: KeyBasedInstrumentControl not implemented")))
     }
 }
 

--- a/src/system_exclusive/machine_control.rs
+++ b/src/system_exclusive/machine_control.rs
@@ -73,8 +73,8 @@ impl MachineControlCommandMsg {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+    pub(crate) fn from_midi(m: &[u8]) -> Result<(Self, usize), ParseError> {
+        Err(ParseError::Invalid(format!("TODO: MachineControlCommandMsg::(0x{:02x}) not implemented", m[0])))
     }
 }
 
@@ -124,7 +124,7 @@ impl MachineControlResponseMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: MachineControlResponseMsg not implemented")))
     }
 }
 

--- a/src/system_exclusive/mod.rs
+++ b/src/system_exclusive/mod.rs
@@ -416,7 +416,7 @@ impl UniversalRealTimeMsg {
                     Ok(Self::TimeCodeFull(time_code))
                 }
             }
-            _ => Err(ParseError::Invalid(format!("TODO: Not implemented"))),
+            _ => Err(ParseError::Invalid(format!("TODO: UniversalRealTimeMsg::(0x{:02x}, 0x{:02x}) not implemented", m[0], m[1]))),
         }
     }
 }
@@ -609,7 +609,7 @@ impl UniversalNonRealTimeMsg {
         }
 
         match (m[0], m[1]) {
-            _ => Err(ParseError::Invalid(format!("TODO: Not implemented"))),
+            _ => Err(ParseError::Invalid(format!("TODO: UniversalNonRealTimeMsg::(0x{:02x}, 0x{:02x}) not implemented", m[0], m[1]))),
         }
     }
 }

--- a/src/system_exclusive/notation.rs
+++ b/src/system_exclusive/notation.rs
@@ -43,7 +43,7 @@ impl BarMarker {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: BarMarker not implemented")))
     }
 }
 
@@ -92,7 +92,7 @@ impl TimeSignature {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: TimeSignature not implemented")))
     }
 }
 
@@ -113,7 +113,7 @@ impl Signature {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: Signature not implemented")))
     }
 }
 

--- a/src/system_exclusive/sample_dump.rs
+++ b/src/system_exclusive/sample_dump.rs
@@ -120,7 +120,7 @@ impl SampleDumpMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: SampleDumpMsg not implemented")))
     }
 
     /// Construct a packet of exactly 120 7-bit "bytes".
@@ -290,7 +290,7 @@ impl ExtendedSampleDumpMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ExtendedSampleDumpMsg not implemented")))
     }
 }
 

--- a/src/system_exclusive/show_control.rs
+++ b/src/system_exclusive/show_control.rs
@@ -25,7 +25,7 @@ impl ShowControlMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ShowControlMsg not implemented")))
     }
 }
 

--- a/src/system_exclusive/tuning.rs
+++ b/src/system_exclusive/tuning.rs
@@ -37,7 +37,7 @@ impl TuningNoteChange {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: TuningNoteChange not implemented")))
     }
 }
 
@@ -94,7 +94,7 @@ impl KeyBasedTuningDump {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: KeyBasedTuningDump not implemented")))
     }
 }
 
@@ -172,7 +172,7 @@ impl ScaleTuningDump1Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ScaleTuningDump1Byte not implemented")))
     }
 }
 
@@ -213,7 +213,7 @@ impl ScaleTuningDump2Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ScaleTuningDump2Byte not implemented")))
     }
 }
 
@@ -240,7 +240,7 @@ impl ScaleTuning1Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ScaleTuning1Byte not implemented")))
     }
 }
 
@@ -269,7 +269,7 @@ impl ScaleTuning2Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ScaleTuning2Byte not implemented")))
     }
 }
 
@@ -383,7 +383,7 @@ impl ChannelBitMap {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Not implemented")))
+        Err(ParseError::Invalid(format!("TODO: ChannelBitMap not implemented")))
     }
 }
 

--- a/src/time_code.rs
+++ b/src/time_code.rs
@@ -633,7 +633,7 @@ mod sysex_types {
 
         #[allow(dead_code)]
         pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), &str> {
-            Err("TODO: not implemented")
+            Err("TODO: TimeCodeCueingSetupMsg not implemented") // TODO breaking change: add m[0] to the error message, change return type to ParseError
         }
     }
 
@@ -748,7 +748,7 @@ mod sysex_types {
 
         #[allow(dead_code)]
         pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), &str> {
-            Err("TODO: not implemented")
+            Err("TODO: TimeCodeCueingMsg not implemented") // TODO breaking change: add m[0] to the error message, change return type to ParseError
         }
     }
 }


### PR DESCRIPTION
My midi filter program crashed due to some message sent from the piano keyboard end I just got
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Invalid("TODO: Not implemented")'
```
I quickly found out that I had no clue what message it could have been, so I improved the error messages so that I will next time :smile:

For some cases there is also a possibility to do a partial implementation, in which case I included the relevant midi bytes into the error message as well, for example `TODO: MachineControlCommandMsg::(0x{:02x}) not implemented`. The only place where I couldn't do this is in `time_code.rs` because the error type was set to `&str` instead of `ParseError` and thus could not return a formatted string without breaking the API — so I added breaking-change-TODOs for these instead.