### PR TITLE
Improve errors

### DIFF
--- a/src/channel_mode.rs
+++ b/src/channel_mode.rs
@@ -1,4 +1,3 @@
-use alloc::format;
 use alloc::vec::Vec;
 use super::parse_error::*;
 use crate::util::*;
@@ -79,7 +78,7 @@ impl ChannelModeMsg {
                 (125, _) => Ok((Self::OmniMode(true), 2)),
                 (126, b2) => Ok((Self::PolyMode(PolyMode::Mono(u8_from_u7(*b2)?)), 2)),
                 (127, _) => Ok((Self::PolyMode(PolyMode::Poly), 2)),
-                _ => Err(ParseError::Invalid(format!("This shouldn't be possible"))),
+                _ => Err(ParseError::Invalid("This shouldn't be possible")),
             }
         } else {
             Err(ParseError::UnexpectedEnd)

--- a/src/channel_voice.rs
+++ b/src/channel_voice.rs
@@ -2,7 +2,6 @@ use super::parse_error::*;
 use super::util::*;
 use alloc::vec::Vec;
 use alloc::vec;
-use alloc::format;
 
 /// Channel-level messages that act on a voice. For instance, turning notes on off,
 /// or modifying sounding notes. Used in [`MidiMsg`](crate::MidiMsg).
@@ -199,7 +198,7 @@ impl ChannelVoiceMsg {
                 0xC => Self::ProgramChange { program: 0 },
                 0xD => Self::ChannelPressure { pressure: 0 },
                 0xE => Self::PitchBend { bend: 0 },
-                _ => return Err(ParseError::Invalid(format!("This shouldn't be possible"))),
+                _ => return Err(ParseError::Invalid("This shouldn't be possible")),
             },
             None => return Err(ParseError::UnexpectedEnd),
         };
@@ -723,9 +722,7 @@ impl ControlChange {
         }
 
         if m[0] > 119 {
-            return Err(ParseError::Invalid(format!(
-                "Tried to parse a control change message, but it looks like a channel mode message"
-            )));
+            return Err(ParseError::Invalid("Tried to parse a control change message, but it looks like a channel mode message"));
         }
 
         let value = u8_from_u7(m[1])?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -159,7 +159,7 @@ impl MidiMsg {
                             return Ok((Self::SystemExclusive { msg }, len));
                         }
                         #[cfg(not(feature = "sysex"))]
-                        return Err(ParseError::Invalid(format!("Got system exclusive message but the crate was built without the sysex feature.")))
+                        return Err(ParseError::SystemExclusiveDisabled)
                     } else if b & 0b00001000 == 0 {
                         let (msg, len) = SystemCommonMsg::from_midi(m, ctx)?;
                         Ok((Self::SystemCommon { msg }, len))

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,4 @@
 use alloc::vec;
-use alloc::format;
 use alloc::vec::Vec;
 
 use super::{
@@ -195,7 +194,7 @@ impl MidiMsg {
                                 let (msg, len) = ChannelModeMsg::from_midi_running(m)?;
                                 Ok((Self::ChannelMode { channel: *channel, msg}, len))
                             }
-                            _ => Err(ParseError::Invalid(format!("ReceiverContext::previous_channel_message may only be a ChannelMode or ChannelVoice message.")))
+                            _ => Err(ParseError::Invalid("ReceiverContext::previous_channel_message may only be a ChannelMode or ChannelVoice message."))
                         }
                     } else {
                         Err(ParseError::ContextlessRunningStatus)

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -57,9 +57,16 @@ impl fmt::Display for ParseError {
             },
             Self::Invalid(s) => write!(f, "{}", s),
             Self::ByteOverflow => write!(f, "A byte exceeded 7 bits"),
-            Self::UndefinedSystemCommonMessage(byte) => write!(f, "Encountered undefined system common message {}", byte),
-            Self::UndefinedSystemRealTimeMessage(byte) => write!(f, "Encountered undefined system real time message {}", byte),
-            Self::UndefinedSystemExclusiveMessage(byte) => write!(f, "Encountered undefined system exclusive message {:?}", byte),
+            Self::UndefinedSystemCommonMessage(byte) => write!(f, "Encountered undefined system common message {:#04x}", byte),
+            Self::UndefinedSystemRealTimeMessage(byte) => write!(f, "Encountered undefined system real time message {:#04x}", byte),
+            Self::UndefinedSystemExclusiveMessage(byte) => {
+                if let Some(byte) = byte {
+                    write!(f, "Encountered undefined system exclusive message {:#04x}", byte)
+                } else {
+                    write!(f, "Encountered undefined system exclusive message {:?}", byte)
+                }
+
+            },
         }
     }
 }

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -1,5 +1,4 @@
-use alloc::string::String;
-use alloc::{fmt};
+use alloc::fmt;
 #[cfg(feature = "std")]
 use std::error;
 /// Returned when [`MidiMsg::from_midi`](crate::MidiMsg::from_midi) and similar where not successful.
@@ -17,7 +16,7 @@ pub enum ParseError {
     /// was built without the sysex feature.
     SystemExclusiveDisabled,
     /// The series of bytes was otherwise invalid.
-    Invalid(String),
+    Invalid(&'static str),
     /// Attempted to use a not yet implemented feature.
     NotImplemented(&'static str),
     /// A byte exceeded 7 bits.

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -11,6 +11,8 @@ pub enum ParseError {
     ContextlessRunningStatus,
     /// Reached end without an End of System Exclusive flag.
     NoEndOfSystemExclusiveFlag,
+    /// Encountered an unexpected End of System Exclusive flag.
+    UnexpectedEndOfSystemExclusiveFlag,
     /// Received a system exclusive message but the crate
     /// was built without the sysex feature.
     SystemExclusiveDisabled,
@@ -20,6 +22,12 @@ pub enum ParseError {
     NotImplemented(&'static str),
     /// A byte exceeded 7 bits.
     ByteOverflow,
+    /// Encountered an undefined system common message
+    UndefinedSystemCommonMessage(u8),
+    /// Encountered an undefined system real time message
+    UndefinedSystemRealTimeMessage(u8),
+    /// Encountered an undefined system exclusive message
+    UndefinedSystemExclusiveMessage(Option<u8>)
 }
 
 #[cfg(feature = "std")]
@@ -39,6 +47,9 @@ impl fmt::Display for ParseError {
             Self::NoEndOfSystemExclusiveFlag => {
                 write!(f, "Tried to read a SystemExclusiveMsg, but reached the end without an End of System Exclusive flag")
             },
+            Self::UnexpectedEndOfSystemExclusiveFlag => {
+                write!(f, "Encountered an unexpected End of System Exclusive flag")
+            }
             Self::SystemExclusiveDisabled => {
                 write!(f, "Received a system exclusive message but the crate was built without the sysex feature")
             }
@@ -47,6 +58,9 @@ impl fmt::Display for ParseError {
             },
             Self::Invalid(s) => write!(f, "{}", s),
             Self::ByteOverflow => write!(f, "A byte exceeded 7 bits"),
+            Self::UndefinedSystemCommonMessage(byte) => write!(f, "Encountered undefined system common message {}", byte),
+            Self::UndefinedSystemRealTimeMessage(byte) => write!(f, "Encountered undefined system real time message {}", byte),
+            Self::UndefinedSystemExclusiveMessage(byte) => write!(f, "Encountered undefined system exclusive message {:?}", byte),
         }
     }
 }

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -13,6 +13,8 @@ pub enum ParseError {
     NoEndOfSystemExclusiveFlag,
     /// The series of bytes was otherwise invalid.
     Invalid(String),
+    /// Attempted to use a not yet implemented feature.
+    NotImplemented(&'static str),
     /// A byte exceeded 7 bits.
     ByteOverflow,
 }
@@ -33,7 +35,10 @@ impl fmt::Display for ParseError {
             ),
             Self::NoEndOfSystemExclusiveFlag => {
                 write!(f, "Tried to read a SystemExclusiveMsg, but reached the end without an End of System Exclusive flag")
-            }
+            },
+            Self::NotImplemented(msg) => {
+                write!(f, "{} is not yet implemented", msg)
+            },
             Self::Invalid(s) => write!(f, "{}", s),
             Self::ByteOverflow => write!(f, "A byte exceeded 7 bits"),
         }

--- a/src/parse_error.rs
+++ b/src/parse_error.rs
@@ -11,6 +11,9 @@ pub enum ParseError {
     ContextlessRunningStatus,
     /// Reached end without an End of System Exclusive flag.
     NoEndOfSystemExclusiveFlag,
+    /// Received a system exclusive message but the crate
+    /// was built without the sysex feature.
+    SystemExclusiveDisabled,
     /// The series of bytes was otherwise invalid.
     Invalid(String),
     /// Attempted to use a not yet implemented feature.
@@ -36,6 +39,9 @@ impl fmt::Display for ParseError {
             Self::NoEndOfSystemExclusiveFlag => {
                 write!(f, "Tried to read a SystemExclusiveMsg, but reached the end without an End of System Exclusive flag")
             },
+            Self::SystemExclusiveDisabled => {
+                write!(f, "Received a system exclusive message but the crate was built without the sysex feature")
+            }
             Self::NotImplemented(msg) => {
                 write!(f, "{} is not yet implemented", msg)
             },

--- a/src/system_common.rs
+++ b/src/system_common.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use super::parse_error::*;
 use super::time_code::*;
 use super::util::*;
@@ -110,13 +109,8 @@ impl SystemCommonMsg {
             Some(0xF2) => Ok((Self::SongPosition(u14_from_midi(&m[1..])?), 3)),
             Some(0xF3) => Ok((Self::SongSelect(u7_from_midi(&m[1..])?), 2)),
             Some(0xF6) => Ok((Self::TuneRequest, 1)),
-            Some(0xF7) => Err(ParseError::Invalid(format!(
-                "Unexpected End of System Exclusive flag"
-            ))),
-            Some(x) => Err(ParseError::Invalid(format!(
-                "Undefined System Common message: {}",
-                x
-            ))),
+            Some(0xF7) => Err(ParseError::UnexpectedEndOfSystemExclusiveFlag),
+            Some(x) => Err(ParseError::UndefinedSystemCommonMessage(*x)),
             _ => panic!("Should not be reachable"),
         }
     }

--- a/src/system_exclusive/controller_destination.rs
+++ b/src/system_exclusive/controller_destination.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use crate::message::Channel;
 use crate::parse_error::*;
 use crate::util::*;
@@ -26,7 +25,7 @@ impl ControllerDestination {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ControllerDestination not implemented")))
+        Err(ParseError::NotImplemented("ControllerDestination"))
     }
 }
 
@@ -60,7 +59,7 @@ impl ControlChangeControllerDestination {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ControlChangeControllerDestination not implemented")))
+        Err(ParseError::NotImplemented("ControlChangeControllerDestination"))
     }
 }
 /// The parameters that can be controlled by [`ControllerDestination`] or

--- a/src/system_exclusive/file_dump.rs
+++ b/src/system_exclusive/file_dump.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use super::DeviceID;
 use crate::parse_error::*;
 use crate::util::*;
@@ -114,7 +113,7 @@ impl FileDumpMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: FileDumpMsg not implemented")))
+        Err(ParseError::NotImplemented("FileDumpMsg"))
     }
 }
 

--- a/src/system_exclusive/file_reference.rs
+++ b/src/system_exclusive/file_reference.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use crate::parse_error::*;
 use crate::util::*;
 use bstr::BString;
@@ -89,7 +88,7 @@ impl FileReferenceMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: FileReferenceMsg not implemented")))
+        Err(ParseError::NotImplemented("FileReferenceMsg"))
     }
 }
 

--- a/src/system_exclusive/global_parameter.rs
+++ b/src/system_exclusive/global_parameter.rs
@@ -2,7 +2,6 @@
 use micromath::F32Ext;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::format;
 use crate::parse_error::*;
 use crate::util::*;
 
@@ -157,7 +156,7 @@ impl GlobalParameterControl {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: GlobalParameterControl not implemented")))
+        Err(ParseError::NotImplemented("GlobalParameterControl"))
     }
 }
 
@@ -191,7 +190,7 @@ impl SlotPath {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: SlotPath not implemented")))
+        Err(ParseError::NotImplemented("SlotPath"))
     }
 }
 
@@ -229,7 +228,7 @@ impl GlobalParameter {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: GlobalParameter not implemented")))
+        Err(ParseError::NotImplemented("GlobalParameter"))
     }
 }
 

--- a/src/system_exclusive/key_based_instrument_control.rs
+++ b/src/system_exclusive/key_based_instrument_control.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use crate::message::Channel;
 use crate::parse_error::*;
 use crate::util::*;
@@ -40,7 +39,7 @@ impl KeyBasedInstrumentControl {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: KeyBasedInstrumentControl not implemented")))
+        Err(ParseError::NotImplemented("KeyBasedInstrumentControl"))
     }
 }
 

--- a/src/system_exclusive/machine_control.rs
+++ b/src/system_exclusive/machine_control.rs
@@ -1,4 +1,3 @@
-use alloc::format;
 use alloc::vec::Vec;
 use crate::parse_error::*;
 use crate::time_code::*;
@@ -73,8 +72,8 @@ impl MachineControlCommandMsg {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn from_midi(m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: MachineControlCommandMsg::(0x{:02x}) not implemented", m[0])))
+    pub(crate) fn from_midi(_: &[u8]) -> Result<(Self, usize), ParseError> {
+        Err(ParseError::NotImplemented("MachineControlCommandMsg"))
     }
 }
 
@@ -124,7 +123,7 @@ impl MachineControlResponseMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: MachineControlResponseMsg not implemented")))
+        Err(ParseError::NotImplemented("MachineControlResponseMsg"))
     }
 }
 

--- a/src/system_exclusive/mod.rs
+++ b/src/system_exclusive/mod.rs
@@ -103,10 +103,13 @@ impl SystemExclusiveMsg {
 
     fn sysex_bytes_from_midi(m: &[u8]) -> Result<&[u8], ParseError> {
         if m.first() != Some(&0xF0) {
-            return Err(ParseError::Invalid(format!(
-                "Undefined System Exclusive message: {:?}",
-                m.first()
-            )));
+            return Err(ParseError::UndefinedSystemExclusiveMessage(
+                if let Some(first_byte) = m.first() {
+                    Some(*first_byte)
+                } else {
+                    None
+                }
+            ))
         }
         for (i, b) in m[1..].iter().enumerate() {
             if b == &0xF7 {

--- a/src/system_exclusive/mod.rs
+++ b/src/system_exclusive/mod.rs
@@ -21,7 +21,6 @@ mod tuning;
 pub use tuning::*;
 
 use alloc::vec::Vec;
-use alloc::format;
 
 use super::general_midi::GeneralMidi;
 use super::parse_error::*;
@@ -410,9 +409,7 @@ impl UniversalRealTimeMsg {
         match (m[0], m[1]) {
             (01, 01) => {
                 if m.len() > 6 {
-                    Err(ParseError::Invalid(format!(
-                        "Extra bytes after a UniversalRealTimeMsg::TimeCodeFull"
-                    )))
+                    Err(ParseError::Invalid("Extra bytes after a UniversalRealTimeMsg::TimeCodeFull"))
                 } else {
                     let time_code = TimeCode::from_midi(&m[2..])?;
                     ctx.time_code = time_code;

--- a/src/system_exclusive/mod.rs
+++ b/src/system_exclusive/mod.rs
@@ -416,7 +416,7 @@ impl UniversalRealTimeMsg {
                     Ok(Self::TimeCodeFull(time_code))
                 }
             }
-            _ => Err(ParseError::Invalid(format!("TODO: UniversalRealTimeMsg::(0x{:02x}, 0x{:02x}) not implemented", m[0], m[1]))),
+            _ => Err(ParseError::NotImplemented("UniversalRealTimeMsg")),
         }
     }
 }
@@ -609,7 +609,7 @@ impl UniversalNonRealTimeMsg {
         }
 
         match (m[0], m[1]) {
-            _ => Err(ParseError::Invalid(format!("TODO: UniversalNonRealTimeMsg::(0x{:02x}, 0x{:02x}) not implemented", m[0], m[1]))),
+            _ => Err(ParseError::NotImplemented("UniversalNonRealTimeMsg")),
         }
     }
 }

--- a/src/system_exclusive/notation.rs
+++ b/src/system_exclusive/notation.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
 use alloc::vec;
-use alloc::format;
 use crate::parse_error::*;
 use crate::util::*;
 
@@ -43,7 +42,7 @@ impl BarMarker {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: BarMarker not implemented")))
+        Err(ParseError::NotImplemented("BarMarker"))
     }
 }
 
@@ -92,7 +91,7 @@ impl TimeSignature {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: TimeSignature not implemented")))
+        Err(ParseError::NotImplemented("TimeSignature"))
     }
 }
 
@@ -113,7 +112,7 @@ impl Signature {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: Signature not implemented")))
+        Err(ParseError::NotImplemented("Signature"))
     }
 }
 

--- a/src/system_exclusive/sample_dump.rs
+++ b/src/system_exclusive/sample_dump.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use crate::parse_error::*;
 use crate::util::*;
 use bstr::BString;
@@ -120,7 +119,7 @@ impl SampleDumpMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: SampleDumpMsg not implemented")))
+        Err(ParseError::NotImplemented("SampleDumpMsg"))
     }
 
     /// Construct a packet of exactly 120 7-bit "bytes".
@@ -290,7 +289,7 @@ impl ExtendedSampleDumpMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ExtendedSampleDumpMsg not implemented")))
+        Err(ParseError::NotImplemented("ExtendedSampleDumpMsg"))
     }
 }
 

--- a/src/system_exclusive/show_control.rs
+++ b/src/system_exclusive/show_control.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use crate::parse_error::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,7 +24,7 @@ impl ShowControlMsg {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ShowControlMsg not implemented")))
+        Err(ParseError::NotImplemented("ShowControlMsg"))
     }
 }
 

--- a/src/system_exclusive/tuning.rs
+++ b/src/system_exclusive/tuning.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use crate::parse_error::*;
 use crate::util::*;
 
@@ -36,7 +35,7 @@ impl TuningNoteChange {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: TuningNoteChange not implemented")))
+        Err(ParseError::NotImplemented("TuningNoteChange"))
     }
 }
 
@@ -93,7 +92,7 @@ impl KeyBasedTuningDump {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: KeyBasedTuningDump not implemented")))
+        Err(ParseError::NotImplemented("KeyBasedTuningDump"))
     }
 }
 
@@ -171,7 +170,7 @@ impl ScaleTuningDump1Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ScaleTuningDump1Byte not implemented")))
+        Err(ParseError::NotImplemented("ScaleTuningDump1Byte"))
     }
 }
 
@@ -212,7 +211,7 @@ impl ScaleTuningDump2Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ScaleTuningDump2Byte not implemented")))
+        Err(ParseError::NotImplemented("ScaleTuningDump2Byte"))
     }
 }
 
@@ -239,7 +238,7 @@ impl ScaleTuning1Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ScaleTuning1Byte not implemented")))
+        Err(ParseError::NotImplemented("ScaleTuning1Byte"))
     }
 }
 
@@ -268,7 +267,7 @@ impl ScaleTuning2Byte {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ScaleTuning2Byte not implemented")))
+        Err(ParseError::NotImplemented("ScaleTuning2Byte"))
     }
 }
 
@@ -382,7 +381,7 @@ impl ChannelBitMap {
 
     #[allow(dead_code)]
     pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
-        Err(ParseError::Invalid(format!("TODO: ChannelBitMap not implemented")))
+        Err(ParseError::NotImplemented("ChannelBitMap"))
     }
 }
 

--- a/src/system_real_time.rs
+++ b/src/system_real_time.rs
@@ -1,5 +1,4 @@
 use alloc::vec::Vec;
-use alloc::format;
 use super::parse_error::*;
 
 /// A fairly limited set of messages used for device synchronization.
@@ -41,10 +40,7 @@ impl SystemRealTimeMsg {
             Some(0xFC) => Ok((Self::Stop, 1)),
             Some(0xFE) => Ok((Self::ActiveSensing, 1)),
             Some(0xFF) => Ok((Self::SystemReset, 1)),
-            Some(x) => Err(ParseError::Invalid(format!(
-                "Undefined System Real Time message: {}",
-                x
-            ))),
+            Some(x) => Err(ParseError::UndefinedSystemRealTimeMessage(*x)),
             None => panic!("Should not be reachable"),
         }
     }

--- a/src/time_code.rs
+++ b/src/time_code.rs
@@ -632,8 +632,8 @@ mod sysex_types {
         }
 
         #[allow(dead_code)]
-        pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), &str> {
-            Err("TODO: TimeCodeCueingSetupMsg not implemented") // TODO breaking change: add m[0] to the error message, change return type to ParseError
+        pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
+            Err(ParseError::NotImplemented("TimeCodeCueingSetupMsg"))
         }
     }
 
@@ -747,8 +747,8 @@ mod sysex_types {
         }
 
         #[allow(dead_code)]
-        pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), &str> {
-            Err("TODO: TimeCodeCueingMsg not implemented") // TODO breaking change: add m[0] to the error message, change return type to ParseError
+        pub(crate) fn from_midi(_m: &[u8]) -> Result<(Self, usize), ParseError> {
+            Err(ParseError::NotImplemented("TimeCodeCueingMsg"))
         }
     }
 }


### PR DESCRIPTION
This pull request replaces most occurrences of `ParseError::Invalid` with more specific `ParseError` variants.

Also, `ParseError::Invalid(String)` is replaced with `ParseError::Invalid(&'static str)` to avoid allocating memory on errors. This means it's no longer possible to trigger allocations with properly crafted input data, which could be a real problem in embedded systems with very little memory. It's also good practice to avoid memory allocations in time critical audio code. 