### PR TITLE
GitHub action for building std/no_std and running tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Cargo build and test
 
 on:
   push:
@@ -16,15 +16,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Install alsa
-      run: sudo apt-get install -y libasound2-dev
+    
+    - name: Build with default features
+      run: cargo build --verbose
+    
+    # Install a toolchain without std, used for no_std builds. 
     - name: Install thumbv8m.main-none-eabihf toolchain
       run: rustup target add thumbv8m.main-none-eabihf
-    - name: Build std
-      run: cargo build --verbose
-    - name: Build no_std with sysex
+      
+    - name: no_std with sysex
       run: cargo build --verbose --target=thumbv8m.main-none-eabihf --no-default-features --features=sysex
-    - name: Build no_std without sysex
+    
+    - name: no_std without sysex
       run: cargo build --verbose --target=thumbv8m.main-none-eabihf --no-default-features
+    
+    # Install alsa, which is needed by the dev dependency midir that gets built when running cargo test
+    - name: Install alsa
+      run: sudo apt-get install -y libasound2-dev
+      
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install thumbv8m.main-none-eabihf toolchain
+      run: rustup target add thumbv8m.main-none-eabihf
     - name: Build std
       run: cargo build --verbose
     - name: Build no_std with sysex

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install alsa
+      run: sudo apt-get install -y libasound2-dev
     - name: Install thumbv8m.main-none-eabihf toolchain
       run: rustup target add thumbv8m.main-none-eabihf
     - name: Build std

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Install thumbv8m.main-none-eabihf toolchain
       run: rustup target add thumbv8m.main-none-eabihf
       
-    - name: no_std with sysex
+    - name: no_std build, sysex feature enabled
       run: cargo build --verbose --target=thumbv8m.main-none-eabihf --no-default-features --features=sysex
     
-    - name: no_std without sysex
+    - name: no_std build, sysex feature not enabled
       run: cargo build --verbose --target=thumbv8m.main-none-eabihf --no-default-features
     
     # Install alsa, which is needed by the dev dependency midir that gets built when running cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,26 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build std
+      run: cargo build --verbose
+    - name: Build no_std with sysex
+      run: cargo build --verbose --target=thumbv8m.main-none-eabihf --no-default-features --features=sysex
+    - name: Build no_std without sysex
+      run: cargo build --verbose --target=thumbv8m.main-none-eabihf --no-default-features
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
When making changes to this crate, one needs to check that both the default and `no_std` builds work, which may not be obvious to contributors. This PR adds a GitHub action that performs the following steps:

* runs a build with default features
* runs a `no_std` build with the `sysex` feature
* runs a `no_std` build without the `sysex` feature
* runs tests

The action gets triggered on pushes to `master` and PRs to `master`.